### PR TITLE
Upgrade friendsofphp/php-cs-fixer dependency to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "composer-plugin-api": "^1.1 || ^2.0",
-        "friendsofphp/php-cs-fixer": "^2.16||^3.0",
+        "friendsofphp/php-cs-fixer": "^2.16.5||^3.0",
         "symfony/console": "^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "composer-plugin-api": "^1.1 || ^2.0",
-        "friendsofphp/php-cs-fixer": "^2.16.5",
+        "friendsofphp/php-cs-fixer": "^2.16||^3.0",
         "symfony/console": "^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
In order to use that library with php 8.0, is necessary  to install `php-cs-fixer` >= 3.0 