### PR TITLE
Check for --no-interactive flag during BC upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ## [0.5.1] - TBA
 - Fix configuration generation
+- Check for --no-interactive flag during BC upgrades
 
 ## [0.5.0] - 2021-09-01
 - Upgrade to PHP-CS-Fixer 3.0 #35 (all breaking changes are due to upstream, check the [UPGRADE-v3.md](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.2/UPGRADE-v3.md) document for a complete list)

--- a/src/Installer/Installer.php
+++ b/src/Installer/Installer.php
@@ -97,6 +97,12 @@ class Installer
         if (false === $this->isBcBreak($currentPackage, $targetPackage)) {
             return;
         }
+        
+        if (! $this->io->isInteractive()) {
+            $this->io->write(sprintf("\n  <info>Skipping configuration upgrade due to --no-interactive flag.</info>"));
+
+            return;
+        }
 
         $question = [
             '  <error>You are upgrading "' . $currentPackage->getPrettyName() . '" with possible BC breaks.</error>',

--- a/src/Installer/Installer.php
+++ b/src/Installer/Installer.php
@@ -97,7 +97,7 @@ class Installer
         if (false === $this->isBcBreak($currentPackage, $targetPackage)) {
             return;
         }
-        
+
         if (! $this->io->isInteractive()) {
             $this->io->write(sprintf("\n  <info>Skipping configuration upgrade due to --no-interactive flag.</info>"));
 

--- a/src/Installer/Installer.php
+++ b/src/Installer/Installer.php
@@ -94,13 +94,13 @@ class Installer
      */
     public function checkUpgrade(PackageInterface $currentPackage, PackageInterface $targetPackage): void
     {
-        if (false === $this->isBcBreak($currentPackage, $targetPackage)) {
-            return;
-        }
-
         if (! $this->io->isInteractive()) {
             $this->io->write(sprintf("\n  <info>Skipping configuration upgrade due to --no-interactive flag.</info>"));
 
+            return;
+        }
+
+        if (false === $this->isBcBreak($currentPackage, $targetPackage)) {
             return;
         }
 

--- a/tests/Installer/InstallerTest.php
+++ b/tests/Installer/InstallerTest.php
@@ -89,6 +89,8 @@ class InstallerTest extends TestCase
             $phpCsWriter->reveal()
         );
 
+        $io->isInteractive()
+            ->willReturn(true);
         $io->askConfirmation(Argument::cetera())
             ->shouldNotBeCalled();
 

--- a/tests/Installer/InstallerTest.php
+++ b/tests/Installer/InstallerTest.php
@@ -118,6 +118,8 @@ class InstallerTest extends TestCase
             $phpCsWriter->reveal()
         );
 
+        $io->isInteractive()
+            ->willReturn(true);
         $io->askConfirmation(Argument::cetera())
             ->shouldBeCalled()
             ->willReturn(false);
@@ -142,6 +144,8 @@ class InstallerTest extends TestCase
             $phpCsWriter->reveal()
         );
 
+        $io->isInteractive()
+            ->willReturn(true);
         $io->askConfirmation(Argument::cetera())
             ->shouldBeCalled()
             ->willReturn(true);
@@ -149,6 +153,35 @@ class InstallerTest extends TestCase
         $io->write(Argument::type('string'))->shouldBeCalled();
         $phpCsWriter->writeConfigFile($this->projectRoot . '/.php-cs-fixer.dist.php', false, true)
             ->shouldBeCalled();
+
+        $installer->checkUpgrade($currentPackage, $targetPackage);
+    }
+
+    public function testCheckUpgradeShouldntWriteWithNoInteractiveInput(): void
+    {
+        $currentPackage = new Package('dummy', '0.1.0', '0.1.0');
+        $targetPackage = new Package('dummy', '0.2.0', '0.2.0');
+
+        $io = $this->prophesize(IOInterface::class);
+        $composer = $this->prophesize(Composer::class);
+        $phpCsWriter = $this->prophesize(PhpCsConfigWriterInterface::class);
+
+        $installer = new Installer(
+            $io->reveal(),
+            $composer->reveal(),
+            $this->projectRoot,
+            $this->composerFilePath,
+            $phpCsWriter->reveal()
+        );
+
+        $io->isInteractive()
+            ->willReturn(false);
+        $io->askConfirmation(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $io->write(Argument::containingString('Skip'))->shouldBeCalled();
+        $phpCsWriter->writeConfigFile(Argument::cetera())
+            ->shouldNotBeCalled();
 
         $installer->checkUpgrade($currentPackage, $targetPackage);
     }


### PR DESCRIPTION
This bug is triggered by:
 * using the `--no-interactive` flag (generally in CI)
 * upgrading the package with BC in the middle, like having a populated vendor with a previous version and doing `composer install` with a newer version in `composer.lock`

This should be backported to 0.4 too.