### PR TITLE
Add dump script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 .phpunit.xml.dist export-ignore
 CHANGELOG.md export-ignore
 composer.lock export-ignore
+dump_rules.* export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.phpunit.result.cache
 /phpunit.xml
 composer.lock
+dump_rules.md

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,7 +16,10 @@ $config->setRiskyAllowed(true);
 $finder = new PhpCsFixer\Finder();
 $autoloadPathProvider = new Facile\CodingStandards\AutoloadPathProvider();
 $finder->in($autoloadPathProvider->getPaths());
-
+$finder->append([
+    __DIR__ . '/.php-cs-fixer.dist.php',
+    __DIR__ . '/dump_rules.php',
+]);
 $config->setFinder($finder);
 
 return $config;

--- a/dump_rules.php
+++ b/dump_rules.php
@@ -58,7 +58,9 @@ function isAlreadyActiveInCurrentRuleset(FixerInterface $fixer): bool
         );
 
         foreach (RuleSets::getSetDefinitions() as $ruleSetDefinition) {
-            $allActiveRules = array_merge($allActiveRules, $ruleSetDefinition->getRules());
+            if (array_key_exists($ruleSetDefinition->getName(), $allActiveRules)) {
+                $allActiveRules = array_merge($allActiveRules, $ruleSetDefinition->getRules());
+            }
         }
     }
 

--- a/dump_rules.php
+++ b/dump_rules.php
@@ -55,11 +55,23 @@ function isAlreadyActiveInCurrentRuleset(FixerInterface $fixer): bool
             (new RiskyRulesProvider())->getRules()
         );
 
-        foreach (RuleSets::getSetDefinitions() as $ruleSetDefinition) {
+        $ruleSets = RuleSets::getSetDefinitions();
+        foreach ($ruleSets as $ruleSetDefinition) {
             if (isIgnoredSet($ruleSetDefinition) || array_key_exists($ruleSetDefinition->getName(), $allActiveRules)) {
                 $allActiveRules = array_merge($allActiveRules, $ruleSetDefinition->getRules());
             }
         }
+
+        do {
+            $foundSet = false;
+            foreach ($allActiveRules as $ruleName => $options) {
+                if (str_starts_with($ruleName, '@')) {
+                    $allActiveRules = array_merge($allActiveRules, $ruleSets[$ruleName]->getRules());
+                    $foundSet = true;
+                    unset($allActiveRules[$ruleName]);
+                }
+            }
+        } while ($foundSet);
     }
 
     return array_key_exists($fixer->getName(), $allActiveRules);

--- a/dump_rules.php
+++ b/dump_rules.php
@@ -1,0 +1,95 @@
+<?php
+
+/** 
+ * This PHP script is useful to dump rules descriptions into Markdown, 
+ * so that it's easier to open PRs with descriptive content aimed at
+ * adding new rules to this repository ruleset.
+ *
+ * Launching this script with not options will dump all rules which are 
+ * not alread enabled. 
+ * 
+ * TODO: Launching it with arguments will dump the listed rules. 
+ */
+
+use Facile\CodingStandards\Rules\DefaultRulesProvider;
+use Facile\CodingStandards\Rules\RiskyRulesProvider;
+use PhpCsFixer\Console\Command\DescribeCommand;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSet\RuleSets;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$fixers = getAllFixers();
+$setDefinitions = RuleSets::getSetDefinitions();
+
+$output = __DIR__ . '/dump_rules.md';
+@unlink($output);
+
+foreach ($fixers as $fixer) {
+    if (isAlreadyActiveInCurrentRuleset($fixer)) {
+        continue;
+    }
+
+    describe($output, $fixer);
+}
+
+/**
+ * @return FixerInterface[]
+ */
+function getAllFixers(): array
+{
+    $fixerFactory = new FixerFactory();
+    $fixerFactory->registerBuiltInFixers();
+
+    return $fixerFactory->getFixers();
+}
+
+function isAlreadyActiveInCurrentRuleset(FixerInterface $fixer): bool
+{
+    static $allActiveRules;
+    if (null === $allActiveRules) {
+        $allActiveRules = array_merge(
+            (new DefaultRulesProvider())->getRules(),
+            (new RiskyRulesProvider())->getRules()
+        );
+
+        foreach (RuleSets::getSetDefinitions() as $ruleSetDefinition) {
+            $allActiveRules = array_merge($allActiveRules, $ruleSetDefinition->getRules());
+        }
+    }
+
+    return array_key_exists($fixer->getName(), $allActiveRules);
+}
+
+function describe(string $outputFile, FixerInterface $fixer): void
+{
+    static $application;
+    if (null === $application) {
+        $command = new DescribeCommand();
+        $application = new Application();
+        $application->add($command);
+        $application->setAutoExit(false);
+    }
+
+    $bufferedOutput = new BufferedOutput();
+
+    echo 'dumping rule ' . $fixer->getName() . '...' . PHP_EOL;
+
+    try {
+        if ($application->run(new ArrayInput(['describe', 'name' => $fixer->getName()]), $bufferedOutput) !== 0) {
+            echo 'Error while describing rule ' . $fixer->getName() . PHP_EOL;
+            echo $bufferedOutput->fetch();
+            exit(1);
+        }
+    } catch (\Throwable $exception) {
+        echo 'Error while running describe for rule: ' . $exception->getMessage() . PHP_EOL;
+        exit(1);
+    }
+
+    file_put_contents($outputFile, $bufferedOutput->fetch(), FILE_APPEND);
+}
+

--- a/dump_rules.php
+++ b/dump_rules.php
@@ -90,6 +90,23 @@ function describe(string $outputFile, FixerInterface $fixer): void
         exit(1);
     }
 
-    file_put_contents($outputFile, $bufferedOutput->fetch(), FILE_APPEND);
+    file_put_contents($outputFile, postProcessOutput($bufferedOutput->fetch()), FILE_APPEND);
+}
+
+function postProcessOutput(string $output): string
+{
+    // replace first line with heading
+    $output = preg_replace('/Description of ([\w_]+) rule\./', '## `$1`', $output);
+    // replace diffs opening with fenced typed code snippet
+    $output = preg_replace('/ +-+ begin diff -+/', '```diff', $output);
+    // replace diffs closing with fenced code snippet
+    $output = preg_replace('/ *\n +-+ end diff -+/', '```', $output);
+    // remove additional diff labels
+    $output = preg_replace('/ +(--- Original|\+\+\+ New|@@ .+ @@)\n/', '', $output);
+    // try to de-indent diff snippets
+    $output = preg_replace('/\n {3}/', "\n", $output);
+
+    // avoid linking issues by mistake
+    return str_replace('Example #', 'Example ', $output);
 }
 

--- a/dump_rules.php
+++ b/dump_rules.php
@@ -23,13 +23,10 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 require __DIR__ . '/vendor/autoload.php';
 
-$fixers = getAllFixers();
-$setDefinitions = RuleSets::getSetDefinitions();
-
 $output = __DIR__ . '/dump_rules.md';
 @unlink($output);
 
-foreach ($fixers as $fixer) {
+foreach (getAllFixers() as $fixer) {
     if (isAlreadyActiveInCurrentRuleset($fixer)) {
         continue;
     }


### PR DESCRIPTION
This PR adds a script that dumps a markdown file with a description of all the unused rules in this repository.

This will be useful in the future to increase the list of rules that we use, and catch up with newer rules that get implemented along the way by the upstream library.

Next steps:
- [ ] add a list of rules to be ignored, because they are undesired
- [ ] open new PRs to enable new rules, using the dumped result in the description