### PR TITLE
Add Doctrine Annotation set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 - Bumping minimum PHP version required to 7.4
 - Bumping minimum PHP-CS-Fixer version required to 3.11
 
+### New rules
+The following rules or groups have been added to the default rule set:
+- `@DoctrineAnnotation`
+
 ## [0.5.3] - 2023-09-13
 - Disable "phpdoc_to_comment" option to avoid false positives with PHPStan @var helpers #46
 

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -14,6 +14,7 @@ final class DefaultRulesProvider implements RulesProviderInterface
      */
     private static $rules = [
         '@PSR2' => true,
+        '@DoctrineAnnotation' => true,
         'align_multiline_comment' => true,
         'array_indentation' => true,
         'array_syntax' => [

--- a/tests/RulesMaintenance/DumperTest.php
+++ b/tests/RulesMaintenance/DumperTest.php
@@ -2,6 +2,7 @@
 
 namespace Facile\CodingStandardsTest\RulesMaintenance;
 
+use PhpCsFixer\Console\Application;
 use PHPUnit\Framework\TestCase;
 
 class DumperTest extends TestCase
@@ -22,10 +23,20 @@ class DumperTest extends TestCase
      */
     public function testNoRuleIsUnlisted(): void
     {
+        if ($this->isPreferLowest()) {
+            $this->markTestSkipped('This test is not reliable with older PHP-CS-Fixer version, due to new rules being added, or included in sets');
+        }
+        
         $dumper = new Dumper();
         $unlistedFixerNames = array_keys(iterator_to_array($dumper->getUnlistedRulesDescription()));
         sort($unlistedFixerNames);
 
         $this->assertEmpty($unlistedFixerNames, implode(\PHP_EOL, ['There are some unlisted rules:', ...$unlistedFixerNames]));
+    }
+
+    private function isPreferLowest(): bool
+    {
+        /** @psalm-suppress InternalClass */
+        return version_compare(Application::VERSION, '3.30.0') < 0;
     }
 }

--- a/tests/RulesMaintenance/DumperTest.php
+++ b/tests/RulesMaintenance/DumperTest.php
@@ -26,7 +26,7 @@ class DumperTest extends TestCase
         if ($this->isPreferLowest()) {
             $this->markTestSkipped('This test is not reliable with older PHP-CS-Fixer version, due to new rules being added, or included in sets');
         }
-        
+
         $dumper = new Dumper();
         $unlistedFixerNames = array_keys(iterator_to_array($dumper->getUnlistedRulesDescription()));
         sort($unlistedFixerNames);

--- a/tests/RulesMaintenance/RulesList.php
+++ b/tests/RulesMaintenance/RulesList.php
@@ -51,13 +51,7 @@ class RulesList
             'combine_consecutive_issets',
             'combine_consecutive_unsets',
             'combine_nested_dirname',
-            'control_structure_braces',
-            'control_structure_continuation_position',
-            'curly_braces_position',
             'declare_parentheses',
-            'doctrine_annotation_braces', // with braces?
-            'doctrine_annotation_indentation',
-            'doctrine_annotation_spaces',
             'empty_loop_body',
             'ereg_to_preg',
             'get_class_to_class_keyword',
@@ -75,7 +69,6 @@ class RulesList
             'no_alternative_syntax',
             'no_blank_lines_after_class_opening',
             'no_homoglyph_names',
-            'no_multiple_statements_per_line',
             'no_superfluous_elseif',
             'no_superfluous_phpdoc_tags',
             'no_trailing_comma_in_singleline',
@@ -105,7 +98,6 @@ class RulesList
             'single_line_empty_body',
             'single_space_around_construct',
             'single_trait_insert_per_statement',
-            'statement_indentation',
             'switch_continue_to_break',
             'ternary_to_elvis_operator',
             'type_declaration_spaces',
@@ -123,7 +115,6 @@ class RulesList
     {
         return [
             'attribute_empty_parentheses',
-            'doctrine_annotation_array_assignment',
             'echo_tag_syntax',
             'escape_implicit_backslashes',
             'explicit_indirect_variable',


### PR DESCRIPTION
This PR is on top of #42 (and leverages it for this description).

It just consists in adding the `@DoctrineAnnotation` set to the default rules. Below a detailed description of the corresponding rules:

<details>
<summary>Rules description</summary>

## `doctrine_annotation_array_assignment`
Doctrine annotations must use configured operator for assignment in arrays.

Fixer is configurable using following options:
* ignored_tags (array): list of tags that must not be treated as Doctrine Annotations; defaults to ['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']
* operator (':', '='): the operator to use; defaults to '='

Fixing examples:
 * Example 1. Fixing with the default configuration.
```diff
 <?php
 /**
- * @Foo({bar : "baz"})
+ * @Foo({bar = "baz"})
  */
 class Bar {}
```

 * Example 2. Fixing with configuration: ['operator' => ':'].
```diff
 <?php
 /**
- * @Foo({bar = "baz"})
+ * @Foo({bar : "baz"})
  */
 class Bar {}
```

## `doctrine_annotation_indentation`
Doctrine annotations must be indented with four spaces.

Fixer is configurable using following options:
* ignored_tags (array): list of tags that must not be treated as Doctrine Annotations; defaults to ['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']
* indent_mixed_lines (bool): whether to indent lines that have content before closing parenthesis; defaults to false

Fixing examples:
 * Example 1. Fixing with the default configuration.
```diff
 <?php
 /**
- *  @Foo(
- *   foo="foo"
- *  )
+ * @Foo(
+ *     foo="foo"
+ * )
  */
 class Bar {}
```

 * Example 2. Fixing with configuration: ['indent_mixed_lines' => true].
```diff
 <?php
 /**
- *  @Foo({@Bar,
- *   @Baz})
+ * @Foo({@Bar,
+ *     @Baz})
  */
 class Bar {}
```

## `doctrine_annotation_braces`
Doctrine annotations without arguments must use the configured syntax.

Fixer is configurable using following options:
* ignored_tags (array): list of tags that must not be treated as Doctrine Annotations; defaults to ['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']
* syntax ('with_braces', 'without_braces'): whether to add or remove braces; defaults to 'without_braces'

Fixing examples:
 * Example 1. Fixing with the default configuration.
```diff
 <?php
 /**
- * @Foo()
+ * @Foo
  */
 class Bar {}
```

 * Example 2. Fixing with configuration: ['syntax' => 'with_braces'].
```diff
 <?php
 /**
- * @Foo
+ * @Foo()
  */
 class Bar {}
```

## `doctrine_annotation_spaces`
Fixes spaces in Doctrine annotations.
There must not be any space around parentheses; commas must be preceded by no space and followed by one space; there must be no space around named arguments assignment operator; there must be one space around array assignment operator.

Fixer is configurable using following options:
* ignored_tags (array): list of tags that must not be treated as Doctrine Annotations; defaults to ['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']
* around_parentheses (bool): whether to fix spaces around parentheses; defaults to true
* around_commas (bool): whether to fix spaces around commas; defaults to true
* before_argument_assignments (null, bool): whether to add, remove or ignore spaces before argument assignment operator; defaults to false
* after_argument_assignments (null, bool): whether to add, remove or ignore spaces after argument assignment operator; defaults to false
* before_array_assignments_equals (null, bool): whether to add, remove or ignore spaces before array `=` assignment operator; defaults to true
* after_array_assignments_equals (null, bool): whether to add, remove or ignore spaces after array assignment `=` operator; defaults to true
* before_array_assignments_colon (null, bool): whether to add, remove or ignore spaces before array `:` assignment operator; defaults to true
* after_array_assignments_colon (null, bool): whether to add, remove or ignore spaces after array assignment `:` operator; defaults to true

Fixing examples:
 * Example 1. Fixing with the default configuration.
```diff
 <?php
 /**
- * @Foo ( )
+ * @Foo()
  */
 class Bar {}
 
 /**
- * @Foo("bar" ,"baz")
+ * @Foo("bar", "baz")
  */
 class Bar2 {}
 
 /**
- * @Foo(foo = "foo", bar = {"foo":"foo", "bar"="bar"})
+ * @Foo(foo="foo", bar={"foo" : "foo", "bar" = "bar"})
  */
 class Bar3 {}
```

 * Example 2. Fixing with configuration: ['after_array_assignments_equals' => false, 'before_array_assignments_equals' => false].
```diff
 <?php
 /**
- * @Foo(foo = "foo", bar = {"foo":"foo", "bar"="bar"})
+ * @Foo(foo="foo", bar={"foo" : "foo", "bar"="bar"})
  */
 class Bar {}
```
</details>