### PR TITLE
Activate `trailing_comma_in_multiline` on all possible elements

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,6 +3,11 @@
 $providers = [
     new Facile\CodingStandards\Rules\DefaultRulesProvider(),
     new Facile\CodingStandards\Rules\RiskyRulesProvider(),
+    new Facile\CodingStandards\Rules\ArrayRulesProvider([
+        'trailing_comma_in_multiline' => [
+            'elements' => ['arrays'], // TODO: drop when PHP 8.0+ is required
+        ],
+    ]),
 ];
 
 $rulesProvider = new Facile\CodingStandards\Rules\CompositeRulesProvider($providers);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ The following rules or groups have been added to the default rule set:
 - `no_homoglyph_names`
 - `set_type_to_cast`
 
+### Changes to existing rules
+- `trailing_comma_in_multiline` now applies on `'arguments', 'match', 'parameters'` elements too
+
 ## [0.5.3] - 2023-09-13
 - Disable "phpdoc_to_comment" option to avoid false positives with PHPStan @var helpers #46
 

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -132,7 +132,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'ternary_operator_spaces' => true,
             'ternary_to_null_coalescing' => true,
             'trailing_comma_in_multiline' => [
-                'elements' => ['arrays'],
+                'elements' => ['arguments', 'arrays', 'match', 'parameters'],
             ],
             'trim_array_spaces' => true,
             'type_declaration_spaces' => true,


### PR DESCRIPTION
This is a feature that will have effect only when using PHP 8.0+, but it's highly useful to make git diffs less noisy when touching the last element in a multi-line declaration. See https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/control_structure/trailing_comma_in_multiline.rst