### PR TITLE
Add syntax rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,9 +3,11 @@
 $providers = [
     new Facile\CodingStandards\Rules\DefaultRulesProvider(),
     new Facile\CodingStandards\Rules\RiskyRulesProvider(),
+    // TODO: drop when PHP 8.0+ is required
     new Facile\CodingStandards\Rules\ArrayRulesProvider([
+        'get_class_to_class_keyword' => false,
         'trailing_comma_in_multiline' => [
-            'elements' => ['arrays'], // TODO: drop when PHP 8.0+ is required
+            'elements' => ['arrays'],
         ],
     ]),
 ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,30 +11,46 @@ The following rules or groups have been added to the default rule set:
 - `@PER-CS2.0` (replacing `@PSR2`)
 - `@PER-CS2.0:risky` (in `RiskyRulesProvider`)
 - `@DoctrineAnnotation`
+- `array_push`
+- `assign_null_coalescing_to_coalesce_equal`
+- `backtick_to_shell_exec`
 - `blank_lines_before_namespace`
 - `class_reference_name_casing`
+- `combine_consecutive_issets`
+- `combine_consecutive_unsets`
+- `combine_nested_dirname`
 - `curly_braces_position`
 - `declare_parentheses`
 - `empty_loop_body`
+- `ereg_to_preg`
+- `get_class_to_class_keyword`
+- `implode_call`
 - `integer_literal_case`
+- `lambda_not_used_import`
 - `linebreak_after_opening_tag`
 - `list_syntax`
 - `long_to_shorthand_operator`
 - `lowercase_static_reference`
 - `magic_constant_casing`
 - `magic_method_casing`
+- `modernize_strpos`
 - `native_function_type_declaration_casing`
 - `native_type_declaration_casing`
 - `no_alternative_syntax`
 - `no_blank_lines_after_class_opening`
+- `no_superfluous_elseif`
+- `no_superfluous_phpdoc_tags`
 - `no_trailing_comma_in_singleline`
 - `no_trailing_comma_in_singleline_function_call`
 - `no_unneeded_curly_braces`
 - `no_unneeded_import_alias`
 - `no_unneeded_braces`
 - `no_unset_cast`
+- `no_useless_else`
+- `no_useless_sprintf`
 - `nullable_type_declaration`
 - `octal_notation`
+- `ordered_traits`
 - `phpdoc_tag_casing`
 - `return_to_yield_from`
 - `phpdoc_trim_consecutive_blank_line_separation`
@@ -43,13 +59,15 @@ The following rules or groups have been added to the default rule set:
 - `single_line_empty_body`
 - `single_space_around_construct`
 - `single_trait_insert_per_statement`
+- `switch_continue_to_break`
 - `type_declaration_spaces`
 - `types_spaces`
 - `no_homoglyph_names`
 - `set_type_to_cast`
+- `ternary_to_elvis_operator`
 
 ### Changes to existing rules
-- `trailing_comma_in_multiline` now applies on `'arguments', 'match', 'parameters'` elements too
+- `trailing_comma_in_multiline` now applies on `'arguments', 'match', 'parameters'` elements too, but only under PHP 8+
 
 ## [0.5.3] - 2023-09-13
 - Disable "phpdoc_to_comment" option to avoid false positives with PHPStan @var helpers #46

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "ext-json": "*",
         "composer-plugin-api": "^1.1 || ^2.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "symfony/console": "^4.0 || ^5.0 || ^6.0"
+        "symfony/console": "^4.0 || ^5.0 || ^6.0",
+        "symfony/polyfill-php80": "^1.28"
     },
     "require-dev": {
         "composer/composer": "^1.3.2 || ^2.0",

--- a/src/AutoloadPathProvider.php
+++ b/src/AutoloadPathProvider.php
@@ -21,13 +21,6 @@ class AutoloadPathProvider
      */
     private $dev;
 
-    /**
-     * AutoloadPathProvider constructor.
-     *
-     * @param null|string $composerFile
-     * @param null|string $projectRoot
-     * @param bool $dev
-     */
     public function __construct(?string $composerFile = null, ?string $projectRoot = null, bool $dev = true)
     {
         $this->composerPath = $composerFile ?: trim(getenv('COMPOSER') ?: '') ?: './composer.json';

--- a/src/Installer/Command/CreateConfigCommand.php
+++ b/src/Installer/Command/CreateConfigCommand.php
@@ -25,17 +25,11 @@ class CreateConfigCommand extends BaseCommand
         parent::__construct($name);
     }
 
-    /**
-     * @return PhpCsConfigWriterInterface
-     */
     public function getConfigWriter(): PhpCsConfigWriterInterface
     {
         return $this->configWriter;
     }
 
-    /**
-     * @param PhpCsConfigWriterInterface $configWriter
-     */
     public function setConfigWriter(PhpCsConfigWriterInterface $configWriter): void
     {
         $this->configWriter = $configWriter;

--- a/src/Installer/Installer.php
+++ b/src/Installer/Installer.php
@@ -41,12 +41,6 @@ class Installer
     private $phpCsWriter;
 
     /**
-     * @param IOInterface $io
-     * @param Composer    $composer
-     * @param null|string $projectRoot
-     * @param null|string $composerPath
-     * @param null|PhpCsConfigWriterInterface $phpCsWriter
-     *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
@@ -87,14 +81,11 @@ class Installer
 
     /**
      * Check if we need to do some upgrades
-     *
-     * @param PackageInterface $currentPackage
-     * @param PackageInterface $targetPackage
      */
     public function checkUpgrade(PackageInterface $currentPackage, PackageInterface $targetPackage): void
     {
         if (! $this->io->isInteractive()) {
-            $this->io->write(sprintf("\n  <info>Skipping configuration upgrade due to --no-interactive flag.</info>"));
+            $this->io->write("\n  <info>Skipping configuration upgrade due to --no-interactive flag.</info>");
 
             return;
         }
@@ -117,7 +108,7 @@ class Installer
             return;
         }
 
-        $this->io->write(sprintf("\n  <info>Writing configuration in project root...</info>"));
+        $this->io->write("\n  <info>Writing configuration in project root...</info>");
 
         $this->phpCsWriter->writeConfigFile($this->projectRoot . '/.php-cs-fixer.dist.php', false, true);
     }
@@ -129,7 +120,7 @@ class Installer
         }
 
         $constraint = $currentPackage->getVersion();
-        if (0 !== strpos($constraint, 'dev-')) {
+        if (! str_starts_with($constraint, 'dev-')) {
             $constraint = '^' . $constraint;
         }
 
@@ -142,17 +133,12 @@ class Installer
         return true;
     }
 
-    /**
-     * @param PhpCsConfigWriterInterface $phpCsWriter
-     */
     public function setPhpCsWriter(PhpCsConfigWriterInterface $phpCsWriter): void
     {
         $this->phpCsWriter = $phpCsWriter;
     }
 
     /**
-     * @param string   $composerFile
-     *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
@@ -169,8 +155,8 @@ class Installer
         $destPath = $this->projectRoot . '/.php-cs-fixer.dist.php';
 
         if (file_exists($destPath)) {
-            $this->io->write(sprintf("\n  <comment>Skipping... CS config file already exists.</comment>"));
-            $this->io->write(sprintf('  <info>Delete .php-cs-fixer.dist.php if you want to install it.</info>'));
+            $this->io->write("\n  <comment>Skipping... CS config file already exists.</comment>");
+            $this->io->write('  <info>Delete .php-cs-fixer.dist.php if you want to install it.</info>');
 
             return;
         }
@@ -189,7 +175,7 @@ class Installer
             return;
         }
 
-        $this->io->write(sprintf("\n  <info>Writing configuration in project root...</info>"));
+        $this->io->write("\n  <info>Writing configuration in project root...</info>");
 
         $this->phpCsWriter->writeConfigFile($this->projectRoot . '/.php-cs-fixer.dist.php', false, true);
     }
@@ -205,7 +191,7 @@ class Installer
         $scriptsDefinition = $this->composerDefinition['scripts'] ?? [];
 
         if (\is_array($scriptsDefinition) && 0 === \count(array_diff_key($scripts, $scriptsDefinition))) {
-            $this->io->write(sprintf("\n  <comment>Skipping... Scripts already exist in composer.json.</comment>"));
+            $this->io->write("\n  <comment>Skipping... Scripts already exist in composer.json.</comment>");
 
             return;
         }
@@ -245,10 +231,6 @@ class Installer
         }
     }
 
-    /**
-     * @param string $composerCommand
-     * @param string $command
-     */
     protected function addComposerScript(string $composerCommand, string $command): void
     {
         /** @var array<string, mixed> $scripts */

--- a/src/Installer/Plugin.php
+++ b/src/Installer/Plugin.php
@@ -29,8 +29,6 @@ class Plugin implements EventSubscriberInterface, PluginInterface, Capable
      * Constructor.
      *
      * Optionally accept the project root into which to install.
-     *
-     * @param null|Installer $installer
      */
     public function __construct(Installer $installer = null)
     {
@@ -42,8 +40,6 @@ class Plugin implements EventSubscriberInterface, PluginInterface, Capable
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     *
-     * @return string
      */
     public static function getPackageName(): string
     {
@@ -83,22 +79,14 @@ class Plugin implements EventSubscriberInterface, PluginInterface, Capable
     /**
      * Apply plugin modifications to Composer.
      *
-     * @param Composer    $composer
-     * @param IOInterface $io
-     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
     public function activate(Composer $composer, IOInterface $io): void {}
 
     /**
-     * @param Composer    $composer
-     * @param IOInterface $io
-     *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     *
-     * @return Installer
      */
     public function getInstaller(Composer $composer, IOInterface $io): Installer
     {
@@ -110,8 +98,6 @@ class Plugin implements EventSubscriberInterface, PluginInterface, Capable
     }
 
     /**
-     * @param PackageEvent $event
-     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      * @throws \Exception
@@ -148,8 +134,6 @@ class Plugin implements EventSubscriberInterface, PluginInterface, Capable
     }
 
     /**
-     * @param PackageEvent $event
-     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      * @throws \Exception

--- a/src/Installer/Writer/PhpCsConfigWriter.php
+++ b/src/Installer/Writer/PhpCsConfigWriter.php
@@ -6,23 +6,12 @@ namespace Facile\CodingStandards\Installer\Writer;
 
 final class PhpCsConfigWriter implements PhpCsConfigWriterInterface
 {
-    /**
-     * @param null|string $filename
-     * @param bool $noDev
-     * @param bool $noRisky
-     */
     public function writeConfigFile(?string $filename = null, bool $noDev = false, bool $noRisky = false): void
     {
         $filename = $filename ?: '.php-cs-fixer.dist.php';
         file_put_contents($filename, $this->createConfigSource($noDev, $noRisky));
     }
 
-    /**
-     * @param bool $noDev
-     * @param bool $noRisky
-     *
-     * @return string
-     */
     private function createConfigSource(bool $noDev = false, bool $noRisky = false): string
     {
         $rulesProviderConfig = $this->createRulesProviderConfig($noRisky);

--- a/src/Installer/Writer/PhpCsConfigWriterInterface.php
+++ b/src/Installer/Writer/PhpCsConfigWriterInterface.php
@@ -6,10 +6,5 @@ namespace Facile\CodingStandards\Installer\Writer;
 
 interface PhpCsConfigWriterInterface
 {
-    /**
-     * @param null|string $filename
-     * @param bool $noDev
-     * @param bool $noRisky
-     */
     public function writeConfigFile(?string $filename = null, bool $noDev = false, bool $noRisky = false): void;
 }

--- a/src/Rules/AbstractRuleProvider.php
+++ b/src/Rules/AbstractRuleProvider.php
@@ -37,6 +37,9 @@ abstract class AbstractRuleProvider implements RulesProviderInterface
      * for older versions.
      */
     private const INTRODUCTION_MAP = [
+        '3.5.0' => [
+            'get_class_to_class_keyword',
+        ],
         '3.6.0' => [
             'class_reference_name_casing',
             'no_unneeded_import_alias',

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -8,7 +8,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
 {
     public function getRules(): array
     {
-        return $this->filterRules([
+        $rules = [
             '@PER-CS2.0' => true,
             '@DoctrineAnnotation' => true,
             'align_multiline_comment' => true,
@@ -143,13 +143,20 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'ternary_operator_spaces' => true,
             'ternary_to_null_coalescing' => true,
             'trailing_comma_in_multiline' => [
-                'elements' => ['arguments', 'arrays', 'match', 'parameters'],
+                'elements' => ['arguments', 'arrays', 'parameters'],
             ],
             'trim_array_spaces' => true,
             'type_declaration_spaces' => true,
             'types_spaces' => true,
             'unary_operator_spaces' => true,
             'whitespace_after_comma_in_array' => true,
-        ]);
+        ];
+
+        if ($this->isAtLeastVersion('3.9.1')) {
+            /** @psalm-suppress PossiblyInvalidArrayAssignment */
+            $rules['trailing_comma_in_multiline']['elements'][] = 'match';
+        }
+
+        return $this->filterRules($rules);
     }
 }

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -143,7 +143,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'ternary_operator_spaces' => true,
             'ternary_to_null_coalescing' => true,
             'trailing_comma_in_multiline' => [
-                'elements' => ['arguments', 'arrays', 'parameters'],
+                'elements' => ['arrays'],
             ],
             'trim_array_spaces' => true,
             'type_declaration_spaces' => true,
@@ -152,9 +152,9 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'whitespace_after_comma_in_array' => true,
         ];
 
-        if ($this->isAtLeastVersion('3.9.1')) {
+        if (\PHP_MAJOR_VERSION >= 8 && $this->isAtLeastVersion('3.9.1')) {
             /** @psalm-suppress PossiblyInvalidArrayAssignment */
-            $rules['trailing_comma_in_multiline']['elements'][] = 'match';
+            $rules['trailing_comma_in_multiline']['elements'] = ['arguments', 'arrays', 'match', 'parameters'];
         }
 
         return $this->filterRules($rules);

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -16,6 +16,8 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'array_syntax' => [
                 'syntax' => 'short',
             ],
+            'assign_null_coalescing_to_coalesce_equal' => true,
+            'backtick_to_shell_exec' => true,
             'binary_operator_spaces' => [
                 'operators' => [
                     '=>' => null,
@@ -33,6 +35,8 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'cast_spaces' => true,
             'class_attributes_separation' => true,
             'class_reference_name_casing' => true,
+            'combine_consecutive_issets' => true,
+            'combine_consecutive_unsets' => true,
             'compact_nullable_typehint' => true,
             'compact_nullable_type_declaration' => true,
             'concat_space' => [
@@ -46,6 +50,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'include' => true,
             'increment_style' => true,
             'integer_literal_case' => true,
+            'lambda_not_used_import' => true,
             'linebreak_after_opening_tag' => true,
             'list_syntax' => true,
             'long_to_shorthand_operator' => true,
@@ -83,6 +88,10 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_spaces_around_offset' => true,
+            'no_superfluous_elseif' => true,
+            'no_superfluous_phpdoc_tags' => [
+                'allow_mixed' => true, // needed to silence Psalm when actual mixed is used
+            ],
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline' => true,
             'no_trailing_comma_in_singleline_array' => true,
@@ -93,6 +102,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'no_unneeded_braces' => true,
             'no_unset_cast' => true,
             'no_unused_imports' => true,
+            'no_useless_else' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
             'not_operator_with_successor_space' => true,
@@ -129,6 +139,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'single_trait_insert_per_statement' => true,
             'space_after_semicolon' => true,
             'standardize_not_equals' => true,
+            'switch_continue_to_break' => true,
             'ternary_operator_spaces' => true,
             'ternary_to_null_coalescing' => true,
             'trailing_comma_in_multiline' => [

--- a/src/Rules/RiskyRulesProvider.php
+++ b/src/Rules/RiskyRulesProvider.php
@@ -10,17 +10,25 @@ final class RiskyRulesProvider extends AbstractRuleProvider
     {
         return $this->filterRules([
             '@PER-CS2.0:risky' => true,
+            'array_push' => true,
+            'combine_nested_dirname' => true,
             'dir_constant' => true,
+            'ereg_to_preg' => true,
             'function_to_constant' => true,
+            'get_class_to_class_keyword' => true,
+            'implode_call' => true,
             'is_null' => true,
             'logical_operators' => true,
+            'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'native_constant_invocation' => true,
             'native_function_invocation' => true,
             'no_alias_functions' => true,
             'no_homoglyph_names' => true,
             'no_php4_constructor' => true,
+            'no_useless_sprintf' => true,
             'non_printable_character' => true,
+            'ordered_traits' => true,
             'php_unit_construct' => true,
             'php_unit_dedicate_assert' => true,
             'php_unit_mock' => true,
@@ -31,6 +39,7 @@ final class RiskyRulesProvider extends AbstractRuleProvider
             'random_api_migration' => true,
             'self_accessor' => true,
             'set_type_to_cast' => true,
+            'ternary_to_elvis_operator' => true,
             'void_return' => true,
         ]);
     }

--- a/tests/Installer/Command/CreateConfigCommandTest.php
+++ b/tests/Installer/Command/CreateConfigCommandTest.php
@@ -30,10 +30,6 @@ class CreateConfigCommandTest extends TestCase
     /**
      * @dataProvider executeProvider
      *
-     * @param array $args
-     * @param bool $noDev
-     * @param bool $noRisky
-     *
      * @throws \Exception
      */
     public function testExecute(array $args, bool $noDev, bool $noRisky): void

--- a/tests/Installer/InstallerTest.php
+++ b/tests/Installer/InstallerTest.php
@@ -68,9 +68,6 @@ class InstallerTest extends TestCase
 
     /**
      * @dataProvider invalidUpgradeProvider
-     *
-     * @param array $currentPackageV
-     * @param array $targetPackageV
      */
     public function testCheckUpgradeTestNotNecessary(array $currentPackageV, array $targetPackageV): void
     {
@@ -99,9 +96,6 @@ class InstallerTest extends TestCase
 
     /**
      * @dataProvider validUpgradeProvider
-     *
-     * @param array $currentPackageV
-     * @param array $targetPackageV
      */
     public function testCheckUpgradeTestNecessary(array $currentPackageV, array $targetPackageV): void
     {

--- a/tests/RulesMaintenance/Dumper.php
+++ b/tests/RulesMaintenance/Dumper.php
@@ -81,6 +81,7 @@ class Dumper
 
         $config = new Config('facile-it/facile-coding-standard');
         $config->setRules($rulesProvider->getRules());
+        $config->setRiskyAllowed(true);
 
         $resolver = new ConfigurationResolver($config, [], '/dev/null', new ToolInfo());
 

--- a/tests/RulesMaintenance/Dumper.php
+++ b/tests/RulesMaintenance/Dumper.php
@@ -19,8 +19,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 class Dumper
 {
     /**
-     * @param $listWarnings
-     *
      * @return \Generator<string, string>
      */
     public function getUnlistedRulesDescription(bool $listWarnings = false): \Generator

--- a/tests/RulesMaintenance/Dumper.php
+++ b/tests/RulesMaintenance/Dumper.php
@@ -82,7 +82,7 @@ class Dumper
         $config = new Config('facile-it/facile-coding-standard');
         $config->setRules($rulesProvider->getRules());
 
-        $resolver = new ConfigurationResolver($config, [], getcwd(), new ToolInfo());
+        $resolver = new ConfigurationResolver($config, [], '/dev/null', new ToolInfo());
 
         yield from $this->generateWithClassNameAsKey($resolver->getFixers());
     }

--- a/tests/RulesMaintenance/RulesList.php
+++ b/tests/RulesMaintenance/RulesList.php
@@ -43,22 +43,6 @@ class RulesList
     public static function getToBeImplementedRules(): array
     {
         return [
-            'array_push',
-            'assign_null_coalescing_to_coalesce_equal',
-            'backtick_to_shell_exec',
-            'combine_consecutive_issets',
-            'combine_consecutive_unsets',
-            'combine_nested_dirname',
-            'ereg_to_preg',
-            'get_class_to_class_keyword',
-            'implode_call',
-            'lambda_not_used_import',
-            'modernize_strpos',
-            'no_superfluous_elseif',
-            'no_superfluous_phpdoc_tags',
-            'no_useless_else',
-            'no_useless_sprintf',
-            'ordered_traits',
             'php_unit_data_provider_static', // with force => false
             'php_unit_dedicate_assert_internal_type',
             'php_unit_expectation',
@@ -67,8 +51,6 @@ class RulesList
             'phpdoc_align', // with left align
             'phpdoc_no_alias_tag',
             'phpdoc_var_annotation_correct_order',
-            'switch_continue_to_break',
-            'ternary_to_elvis_operator',
         ];
     }
 

--- a/tests/RulesMaintenance/RulesList.php
+++ b/tests/RulesMaintenance/RulesList.php
@@ -43,6 +43,7 @@ class RulesList
     public static function getToBeImplementedRules(): array
     {
         return [
+            'get_class_to_class_keyword', // already active, shut off here due to PHP 7.4 support
             'php_unit_data_provider_static', // with force => false
             'php_unit_dedicate_assert_internal_type',
             'php_unit_expectation',


### PR DESCRIPTION
This is another batch of rules to be added, this time about syntax.

Here's the rule description:

<details>

## `no_useless_sprintf`
There must be no `sprintf` calls with only the first argument.

Fixer applying this rule is risky.
Risky when if the `sprintf` function is overridden.

Fixing examples:
 * Example 1.
```diff
 <?php
-$foo = sprintf('bar');
+$foo = 'bar';
```

## `no_useless_else`
There should not be useless `else` cases.

Fixing examples:
 * Example 1.
```diff
 <?php
 if ($a) {
     return 1;
-} else {
+}  
     return 2;
-}
+
```

## `no_superfluous_elseif`
Replaces superfluous `elseif` with `if`.

Fixing examples:
 * Example 1.
```diff
 <?php
 if ($a) {
     return 1;
-} elseif ($b) {
+}
+if ($b) {
     return 2;
 }
```

## `implode_call`
Function `implode` must be called with 2 arguments in the documented order.

Fixer applying this rule is risky.
Risky when the function `implode` is overridden.

Fixing examples:
 * Example 1.
```diff
 <?php
-implode($pieces, '');
+implode('', $pieces);
```

 * Example 2.
```diff
 <?php
-implode($pieces);
+implode('', $pieces);
```

## `modernize_strpos`
Replace `strpos()` calls with `str_starts_with()` or `str_contains()` if possible.

Fixer applying this rule is risky.
Risky if `strpos`, `str_starts_with` or `str_contains` functions are overridden.

Fixing examples:
 * Example 1.
```diff
 <?php
-if (strpos($haystack, $needle) === 0) {}
-if (strpos($haystack, $needle) !== 0) {}
-if (strpos($haystack, $needle) !== false) {}
-if (strpos($haystack, $needle) === false) {}
+if (str_starts_with($haystack, $needle)  ) {}
+if (!str_starts_with($haystack, $needle)  ) {}
+if (str_contains($haystack, $needle)  ) {}
+if (!str_contains($haystack, $needle)  ) {}
```

## `combine_nested_dirname`
Replace multiple nested calls of `dirname` by only one call with second `$level` parameter. Requires PHP >= 7.0.

Fixer applying this rule is risky.
Risky when the function `dirname` is overridden.

Fixing examples:
 * Example 1.
```diff
 <?php
-dirname(dirname(dirname($path)));
+dirname($path, 3);
```

## `lambda_not_used_import`
Lambda must not import variables it doesn't use.

Fixing examples:
 * Example 1.
```diff
 <?php
-$foo = function() use ($bar) {};
+$foo = function() {};
```

## `combine_consecutive_unsets`
Calling `unset` on multiple items should be done in one call.

Fixing examples:
 * Example 1.
```diff
 <?php
-unset($a); unset($b);
+unset($a, $b); 
```

## `backtick_to_shell_exec`
Converts backtick operators to `shell_exec` calls.
Conversion is done only when it is non risky, so when special chars like single-quotes, double-quotes and backticks are not used inside the command.

Fixing examples:
 * Example 1.
```diff
 <?php
-$plain = `ls -lah`;
-$withVar = `ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}`;
+$plain = shell_exec("ls -lah");
+$withVar = shell_exec("ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}");
```

## `no_superfluous_phpdoc_tags`
Removes `@param`, `@return` and `@var` tags that don't provide any useful information.

Fixer is configurable using following options:
* allow_mixed (bool): whether type `mixed` without description is allowed (`true`) or considered superfluous (`false`); defaults to false
* remove_inheritdoc (bool): remove `@inheritDoc` tags; defaults to false
* allow_unused_params (bool): whether `param` annotation without actual signature is allowed (`true`) or considered superfluous (`false`); defaults to false

Fixing examples:
 * Example 1. Fixing with the default configuration.
```diff
 <?php
 class Foo {
     /**
-     * @param Bar $bar
-     * @param mixed $baz
      *
-     * @return Baz
      */
     public function doFoo(Bar $bar, $baz): Baz {}
 }
```

 * Example 2. Fixing with configuration: ['allow_mixed' => true].
```diff
 <?php
 class Foo {
     /**
-     * @param Bar $bar
      * @param mixed $baz
      */
     public function doFoo(Bar $bar, $baz) {}
 }
```

 * Example 3. Fixing with configuration: ['remove_inheritdoc' => true].
```diff
 <?php
 class Foo {
     /**
-     * @inheritDoc
+     *
      */
     public function doFoo(Bar $bar, $baz) {}
 }
```

 * Example 4. Fixing with configuration: ['allow_unused_params' => true].
```diff
 <?php
 class Foo {
     /**
-     * @param Bar $bar
-     * @param mixed $baz
      * @param string|int|null $qux
      */
     public function doFoo(Bar $bar, $baz /*, $qux = null */) {}
 }
```

## `combine_consecutive_issets`
Using `isset($var) &&` multiple times should be done in one call.

Fixing examples:
 * Example 1.
```diff
 <?php
-$a = isset($a) && isset($b);
+$a = isset($a, $b)  ;
```

## `ternary_to_elvis_operator`
Use the Elvis operator `?:` where possible.

Fixer applying this rule is risky.
Risky when relying on functions called on both sides of the `?` operator.

Fixing examples:
 * Example 1.
```diff
 <?php
-$foo = $foo ? $foo : 1;
+$foo = $foo ?  : 1;
```

 * Example 2.
```diff
-<?php $foo = $bar[a()] ? $bar[a()] : 1; # "risky" sample, "a()" only gets called once after fixing
+<?php $foo = $bar[a()] ?  : 1; # "risky" sample, "a()" only gets called once after fixing
```

## `get_class_to_class_keyword`
Replace `get_class` calls on object variables with class keyword syntax.

Fixer applying this rule is risky.
Risky if the `get_class` function is overridden.

Fixing examples:
 * Example 1.
```diff
 <?php
-get_class($a);
+$a::class;
```

 * Example 2.
```diff
 <?php
 
 $date = new \DateTimeImmutable();
-$class = get_class($date);
+$class = $date::class;
```

## `switch_continue_to_break`
Switch case must not be ended with `continue` but with `break`.

Fixing examples:
 * Example 1.
```diff
 <?php
 switch ($foo) {
     case 1:
-        continue;
+        break;
 }
```

 * Example 2.
```diff
 <?php
 switch ($foo) {
     case 1:
         while($bar) {
             do {
-                continue 3;
+                break 3;
             } while(false);
 
             if ($foo + 1 > 3) {
                 continue;
             }
 
-            continue 2;
+            break 2;
         }
 }
```

## `ordered_traits`
Trait `use` statements must be sorted alphabetically.

Fixer applying this rule is risky.
Risky when depending on order of the imports.

Fixer is configurable using following option:
* case_sensitive (bool): whether the sorting should be case sensitive; defaults to false

Fixing examples:
 * Example 1. Fixing with the default configuration.
```diff
 <?php class Foo { 
-use Z; use A; }
+use A; use Z; }
```

 * Example 2. Fixing with configuration: ['case_sensitive' => true].
```diff
 <?php class Foo { 
-use Aaa; use AA; }
+use AA; use Aaa; }
```

## `array_push`
Converts simple usages of `array_push($x, $y);` to `$x[] = $y;`.

Fixer applying this rule is risky.
Risky when the function `array_push` is overridden.

Fixing examples:
 * Example 1.
```diff
 <?php
-array_push($x, $y);
+$x[] = $y;
```

## `ereg_to_preg`
Replace deprecated `ereg` regular expression functions with `preg`.

Fixer applying this rule is risky.
Risky if the `ereg` function is overridden.

Fixing examples:
 * Example 1.
```diff
-<?php $x = ereg('[A-Z]');
+<?php $x = preg_match('/[A-Z]/D');
```

## `assign_null_coalescing_to_coalesce_equal`
Use the null coalescing assignment operator `??=` where possible.

Fixing examples:
 * Example 1.
```diff
 <?php
-$foo = $foo ?? 1;
+$foo ??= 1;
```
</details>