### PR TITLE
Drop additional elements in `trailing_comma_in_multiline`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,9 +6,6 @@ $providers = [
     // TODO: drop when PHP 8.0+ is required
     new Facile\CodingStandards\Rules\ArrayRulesProvider([
         'get_class_to_class_keyword' => false,
-        'trailing_comma_in_multiline' => [
-            'elements' => ['arrays'],
-        ],
     ]),
 ];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,6 @@ The following rules or groups have been added to the default rule set:
 
 ### Changes to existing rules
 - `phpdoc_align` is now enabled with config `left`
-- `trailing_comma_in_multiline` now applies on `'arguments', 'match', 'parameters'` elements too, but only under PHP 8+
 - `ordered_imports` is now falling back to PER-CS configuration, which is not the same as the default one
 
 ### Removed rules

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -151,11 +151,6 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'whitespace_after_comma_in_array' => true,
         ];
 
-        if (\PHP_MAJOR_VERSION >= 8 && $this->isAtLeastVersion('3.9.1')) {
-            /** @psalm-suppress PossiblyInvalidArrayAssignment */
-            $rules['trailing_comma_in_multiline']['elements'] = ['arguments', 'arrays', 'match', 'parameters'];
-        }
-
         return $this->filterRules($rules);
     }
 }


### PR DESCRIPTION
I have to track back on the `trailing_comma_in_multiline` modifications, since the new elements allow for trailing commas only in PHP 8+, and for now we still support 7.4. The runtime language check was insufficient, since it would break on libraries, which may have similar requirements (support for PHP 7), but may be executed with higher language versions.

I will be creating a follow-up issue to track the revert of this PR, and put it into a milestone containing the bump to PHP 8.