### PR TITLE
Remove `unary_operator_spaces` from 3.36.0 onward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Multiple rules are removed (but still applied) since they're already covered in 
 - `return_type_declaration`
 - `short_scalar_cast`
 - `ternary_operator_spaces`
+- `unary_operator_spaces`
 
 ## [0.5.3] - 2023-09-13
 - Disable "phpdoc_to_comment" option to avoid false positives with PHPStan @var helpers #46

--- a/src/Rules/AbstractRuleProvider.php
+++ b/src/Rules/AbstractRuleProvider.php
@@ -69,6 +69,14 @@ abstract class AbstractRuleProvider implements RulesProviderInterface
     ];
 
     /**
+     * This array maps the usage of rules into rulesets (like PER-CS) in new versions of PHP-CS-Fixer, hence avoiding the
+     * overriding.
+     */
+    private const INCLUSION_MAP = [
+        '3.36.0' => ['unary_operator_spaces'],
+    ];
+
+    /**
      * Filter rules, with a dynamic filter depending on the PHP-CS-Fixer version in use.
      *
      * @template T of array<string, mixed>
@@ -85,6 +93,14 @@ abstract class AbstractRuleProvider implements RulesProviderInterface
                     unset($rules[$oldRule]);
                 } else {
                     unset($rules[$newRule]);
+                }
+            }
+        }
+
+        foreach (self::INCLUSION_MAP as $version => $newRules) {
+            if ($this->isAtLeastVersion($version)) {
+                foreach ($newRules as $name) {
+                    unset($rules[$name]);
                 }
             }
         }


### PR DESCRIPTION
This is due to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7303

When a rule gets included in a ruleset like PER-CS, it makes the [test fail](https://github.com/facile-it/facile-coding-standard/actions/runs/6688071746/job/18169592564#step:5:26) due to being overridden in our set. This new map allows it to be selectively removed.