### PR TITLE
Move long_to_shorthand_operator to risky provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ---------
 
+## [1.0.1] - TBA
+- Move `long_to_shorthand_operator` to `RiskyRulesProvider` (#62)
+
 ## [1.0.0] - 2023-10-30
 - Bumping minimum PHP version required to 7.4
 - Bumping minimum PHP-CS-Fixer version required to 3.4

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -53,7 +53,6 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'lambda_not_used_import' => true,
             'linebreak_after_opening_tag' => true,
             'list_syntax' => true,
-            'long_to_shorthand_operator' => true,
             'magic_constant_casing' => true,
             'magic_method_casing' => true,
             'method_chaining_indentation' => true,

--- a/src/Rules/RiskyRulesProvider.php
+++ b/src/Rules/RiskyRulesProvider.php
@@ -20,6 +20,7 @@ final class RiskyRulesProvider extends AbstractRuleProvider
             'implode_call' => true,
             'is_null' => true,
             'logical_operators' => true,
+            'long_to_shorthand_operator' => true,
             'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'native_constant_invocation' => true,


### PR DESCRIPTION
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7418 declared `long_to_shorthand_operator` risky, due to and edge case with strings being accessed via index: https://3v4l.org/GI1NW