### PR TITLE
Map new rules from 3.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+## [1.2.0] - 2024-01-22
+- Add new `numeric_literal_separator` rule (#65)
+- Map new heredoc rules as "to be discussed" (`heredoc_closing_marker`, `multiline_string_to_heredoc`) 
+
 ## [1.1.0] - 2023-12-28
 - Add new risky `class_keyword` rule (#64)
   NB: the rule is experimental, and relies on runtime autoload to determine if a FCQN refers to an existing class

--- a/src/Rules/AbstractRuleProvider.php
+++ b/src/Rules/AbstractRuleProvider.php
@@ -67,6 +67,7 @@ abstract class AbstractRuleProvider implements RulesProviderInterface
         '3.32.0' => ['no_unneeded_braces'],
         '3.33.0' => ['native_type_declaration_casing'],
         '3.42.0' => ['class_keyword'],
+        '3.47.0' => ['numeric_literal_separator'],
     ];
 
     /**

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -101,6 +101,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'not_operator_with_successor_space' => true,
             'normalize_index_brace' => true,
             'nullable_type_declaration' => true,
+            'numeric_literal_separator' => true,
             'object_operator_without_whitespace' => true,
             'octal_notation' => true,
             'operator_linebreak' => true,

--- a/tests/RulesMaintenance/RulesList.php
+++ b/tests/RulesMaintenance/RulesList.php
@@ -60,6 +60,8 @@ class RulesList
             'escape_implicit_backslashes',
             'explicit_indirect_variable',
             'global_namespace_import',
+            'heredoc_closing_marker', // possibly undesired?
+            'multiline_string_to_heredoc', // possibly undesired?
             'multiline_whitespace_before_semicolons', // with new_line_for_chained_calls
             'ordered_types',
             'php_unit_method_casing',


### PR DESCRIPTION
CI started failing for new rules introduced in 3.47.0: https://github.com/facile-it/facile-coding-standard/actions/runs/7606208767/job/20711625112#step:5:67

```1) Facile\CodingStandardsTest\RulesMaintenance\DumperTest::testNoRuleIsUnlisted
There are some unlisted rules:
heredoc_closing_marker
multiline_string_to_heredoc
numeric_literal_separator
Failed asserting that an array is empty.```

The heredoc rules are debatable, while `numeric_literal_separator` is useful, let's adopt it (it's usable since 7.4, so no compat issues).