### PR TITLE
Fall back to default config for `trailing_comma_in_multiline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+## [1.3.0] - TBA
+- Drop support for Symfony below 5.4 (#72)
+- Require PHP-CS-Fixer 3.53+ (#72)
+
 ## [1.2.0] - 2024-01-22
 - Add new `numeric_literal_separator` rule (#65)
 - Map new heredoc rules as "to be discussed" (`heredoc_closing_marker`, `multiline_string_to_heredoc`) 

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "composer-plugin-api": "^1.1 || ^2.0",
-        "friendsofphp/php-cs-fixer": "^3.4",
-        "symfony/console": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "friendsofphp/php-cs-fixer": "^3.53",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/polyfill-php80": "^1.0"
     },
     "require-dev": {

--- a/src/AutoloadPathProvider.php
+++ b/src/AutoloadPathProvider.php
@@ -107,7 +107,7 @@ class AutoloadPathProvider
         return array_reduce(
             $autoload,
             \Closure::fromCallable([$this, 'autoloadReducer']),
-            []
+            [],
         );
     }
 

--- a/src/Installer/Command/CreateConfigCommand.php
+++ b/src/Installer/Command/CreateConfigCommand.php
@@ -47,7 +47,7 @@ class CreateConfigCommand extends BaseCommand
             ->setHelp(
                 <<<'HELP'
                     Write config file in <comment>.php-cs-fixer.dist.php</comment>.
-                    HELP
+                    HELP,
             )
         ;
     }
@@ -59,7 +59,7 @@ class CreateConfigCommand extends BaseCommand
         $configWriter->writeConfigFile(
             '.php-cs-fixer.dist.php',
             (bool) $input->getOption('no-dev'),
-            (bool) $input->getOption('no-risky')
+            (bool) $input->getOption('no-risky'),
         );
 
         return 0;

--- a/src/Installer/Installer.php
+++ b/src/Installer/Installer.php
@@ -51,7 +51,7 @@ class Installer
         Composer $composer,
         ?string $projectRoot = null,
         ?string $composerPath = null,
-        ?PhpCsConfigWriterInterface $phpCsWriter = null
+        ?PhpCsConfigWriterInterface $phpCsWriter = null,
     ) {
         $this->io = $io;
         // Get composer.json location
@@ -100,7 +100,7 @@ class Installer
             '  <error>You are upgrading "' . $currentPackage->getPrettyName() . '" with possible BC breaks.</error>',
             sprintf(
                 '  <question>%s</question>',
-                'Do you want to write the new configuration? (Y/n)'
+                'Do you want to write the new configuration? (Y/n)',
             ),
         ];
 
@@ -170,7 +170,7 @@ class Installer
         $question = [
             sprintf(
                 "  <question>%s</question>\n",
-                'Do you want to create the CS configuration in your project root? (Y/n)'
+                'Do you want to create the CS configuration in your project root? (Y/n)',
             ),
             '  <info>It will create a .php-cs-fixer.dist.php file in your project root directory.</info> ',
         ];
@@ -205,7 +205,7 @@ class Installer
         $question = [
             sprintf(
                 "  <question>%s</question>\n",
-                'Do you want to add scripts to composer.json? (Y/n)'
+                'Do you want to add scripts to composer.json? (Y/n)',
             ),
             '  <info>It will add two scripts:</info>',
             '  - <info>cs-check</info>',

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -141,7 +141,6 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'standardize_not_equals' => true,
             'switch_continue_to_break' => true,
             'ternary_to_null_coalescing' => true,
-            'trailing_comma_in_multiline' => true,
             'trim_array_spaces' => true,
             'type_declaration_spaces' => true,
             'types_spaces' => true,

--- a/src/Rules/DefaultRulesProvider.php
+++ b/src/Rules/DefaultRulesProvider.php
@@ -141,9 +141,7 @@ final class DefaultRulesProvider extends AbstractRuleProvider
             'standardize_not_equals' => true,
             'switch_continue_to_break' => true,
             'ternary_to_null_coalescing' => true,
-            'trailing_comma_in_multiline' => [
-                'elements' => ['arrays'],
-            ],
+            'trailing_comma_in_multiline' => true,
             'trim_array_spaces' => true,
             'type_declaration_spaces' => true,
             'types_spaces' => true,

--- a/tests/AutoloadPathProviderTest.php
+++ b/tests/AutoloadPathProviderTest.php
@@ -44,7 +44,7 @@ class AutoloadPathProviderTest extends TestCase
         $provider = new AutoloadPathProvider(
             $this->composerFilePath,
             $this->projectRoot,
-            true
+            true,
         );
 
         $expected = ['src/', 'tests/'];
@@ -56,7 +56,7 @@ class AutoloadPathProviderTest extends TestCase
         $provider = new AutoloadPathProvider(
             $this->composerFilePath,
             $this->projectRoot,
-            false
+            false,
         );
 
         $expected = ['src/'];
@@ -86,7 +86,7 @@ class AutoloadPathProviderTest extends TestCase
         $provider = new AutoloadPathProvider(
             $this->composerFilePath,
             $this->projectRoot,
-            false
+            false,
         );
 
         file_put_contents($this->composerFilePath, '');

--- a/tests/Installer/Command/CreateConfigCommandTest.php
+++ b/tests/Installer/Command/CreateConfigCommandTest.php
@@ -44,7 +44,7 @@ class CreateConfigCommandTest extends TestCase
         $writer->writeConfigFile(
             '.php-cs-fixer.dist.php',
             $noDev,
-            $noRisky
+            $noRisky,
         )
             ->shouldBeCalled();
 

--- a/tests/Installer/InstallerTest.php
+++ b/tests/Installer/InstallerTest.php
@@ -92,7 +92,7 @@ class InstallerTest extends TestCase
             $composer->reveal(),
             $this->projectRoot,
             $this->composerFilePath,
-            $phpCsWriter->reveal()
+            $phpCsWriter->reveal(),
         );
 
         $io->isInteractive()
@@ -123,7 +123,7 @@ class InstallerTest extends TestCase
             $composer->reveal(),
             $this->projectRoot,
             $this->composerFilePath,
-            $phpCsWriter->reveal()
+            $phpCsWriter->reveal(),
         );
 
         $io->isInteractive()
@@ -149,7 +149,7 @@ class InstallerTest extends TestCase
             $composer->reveal(),
             $this->projectRoot,
             $this->composerFilePath,
-            $phpCsWriter->reveal()
+            $phpCsWriter->reveal(),
         );
 
         $io->isInteractive()
@@ -179,7 +179,7 @@ class InstallerTest extends TestCase
             $composer->reveal(),
             $this->projectRoot,
             $this->composerFilePath,
-            $phpCsWriter->reveal()
+            $phpCsWriter->reveal(),
         );
 
         $io->isInteractive()
@@ -215,7 +215,7 @@ class InstallerTest extends TestCase
             $composer->reveal(),
             $this->projectRoot,
             $this->composerFilePath,
-            $phpCsWriter->reveal()
+            $phpCsWriter->reveal(),
         );
         $installer->requestCreateCsConfig();
     }
@@ -238,7 +238,7 @@ class InstallerTest extends TestCase
             $composer->reveal(),
             $this->projectRoot,
             $this->composerFilePath,
-            $phpCsWriter->reveal()
+            $phpCsWriter->reveal(),
         );
 
         $installer->requestCreateCsConfig();
@@ -264,7 +264,7 @@ class InstallerTest extends TestCase
             $composer->reveal(),
             $this->projectRoot,
             $this->composerFilePath,
-            $phpCsWriter->reveal()
+            $phpCsWriter->reveal(),
         );
 
         $installer->requestCreateCsConfig();

--- a/tests/Rules/AbstractRulesProviderTest.php
+++ b/tests/Rules/AbstractRulesProviderTest.php
@@ -33,7 +33,7 @@ abstract class AbstractRulesProviderTest extends TestCase
         $this->assertSame(
             $this->shouldBeRisky(),
             $fixer->isRisky(),
-            sprintf('Fixer %s is %s as expected', $ruleName, $this->shouldBeRisky() ? 'risky' : 'NOT risky')
+            sprintf('Fixer %s is %s as expected', $ruleName, $this->shouldBeRisky() ? 'risky' : 'NOT risky'),
         );
     }
 
@@ -49,7 +49,7 @@ abstract class AbstractRulesProviderTest extends TestCase
             $this->assertSame(
                 $this->shouldBeRisky(),
                 $fixer->isRisky(),
-                sprintf('Ruleset %s includes %s rules, such as %s', $ruleSetName, $this->shouldBeRisky() ? 'risky' : 'NOT risky', $ruleName)
+                sprintf('Ruleset %s includes %s rules, such as %s', $ruleSetName, $this->shouldBeRisky() ? 'risky' : 'NOT risky', $ruleName),
             );
         }
     }
@@ -148,18 +148,18 @@ abstract class AbstractRulesProviderTest extends TestCase
 
             $this->assertEquals($defaultConfiguration, $ruleConfiguration, sprintf(
                 'Ruleset relies on default configuration for rule %s, but it is being overridden',
-                $ruleName
+                $ruleName,
             ));
         } elseif ($ruleConfiguration === true) {
             $this->assertEquals($ruleSetConfiguration, $defaultConfiguration, sprintf(
                 'Ruleset does not use the default config for rule %s, and it is being overridden with "true" in %s',
                 $ruleName,
-                \get_class($rulesProvider)
+                \get_class($rulesProvider),
             ));
         } else {
             $this->assertEquals($ruleSetConfiguration, $ruleConfiguration, sprintf(
                 'Rule %s has a different configuration from the one from ruleset',
-                $ruleName
+                $ruleName,
             ));
         }
     }


### PR DESCRIPTION
This is thanks to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7916 that adds `trailing_comma_in_multiline` to the PER-CS-2.0 ruleset.

This should fix the CI: https://github.com/facile-it/facile-coding-standard/actions/runs/8683344265/job/23816753810