### PR TITLE
Allow overriding of `trailing_comma_in_multiline`

### DIFF
--- a/tests/Rules/AbstractRulesProviderTest.php
+++ b/tests/Rules/AbstractRulesProviderTest.php
@@ -66,6 +66,7 @@ abstract class AbstractRulesProviderTest extends TestCase
         $allowedOverrides = [
             'binary_operator_spaces',
             'single_class_element_per_statement',
+            'trailing_comma_in_multiline', // see #72
         ];
 
         if (\in_array($ruleName, $allowedOverrides)) {


### PR DESCRIPTION
This is to fix the CI after that #72 wasn't viable.