### PR TITLE
Add support for Symfony 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,19 +23,12 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         deps:
           - "highest"
-        composer-options:
-          - ""
         include:
           - php-version: "7.4"
             deps: "lowest"
-          - php-version: "8.5"
-            composer-options: "--ignore-platform-req=php+"
-          - php-version: "8.4"
-            composer-options: "--ignore-platform-req=php+"
-            composer-minimum-stability: "beta"
-            symfony-version: "^8.0.0-BETA1"
 
     steps:
       - name: "Checkout"
@@ -51,10 +44,6 @@ jobs:
           ini-values: "zend.assertions=1"
           tools: flex
 
-      - name: Configure Composer minimum-stability
-        if: matrix.composer-minimum-stability
-        run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
-
       - name: Remove Psalm during tests
         if: ${{ matrix.composer-minimum-stability || matrix.php-version == '8.4' }}
         run: composer remove --dev --no-update vimeo/psalm psalm/plugin-phpunit
@@ -63,9 +52,9 @@ jobs:
         uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.deps }}
-          composer-options: "--prefer-dist ${{ matrix.composer-options }}"
+          composer-options: "--prefer-dist"
         env:
-            SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
+          COMPOSER_NO_SECURITY_BLOCKING: "1"
 
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --coverage-clover=coverage.xml"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
         run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
 
       - name: Remove Psalm during tests
-        if: matrix.composer-minimum-stability
+        if: ${{ matrix.composer-minimum-stability || matrix.php-version == '8.4' }}
         run: composer remove --dev --no-update vimeo/psalm psalm/plugin-phpunit
 
       - name: "Install dependencies"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         deps:
           - "highest"
         composer-options:
@@ -29,8 +30,6 @@ jobs:
         include:
           - php-version: "7.4"
             deps: "lowest"
-          - php-version: "8.4"
-            composer-options: "--prefer-dist --ignore-platform-req=php+"
           - php-version: "8.5"
             composer-options: "--prefer-dist --ignore-platform-req=php+"
           - php-version: "8.4"
@@ -56,6 +55,9 @@ jobs:
         if: matrix.composer-minimum-stability
         run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
 
+      - name: Remove Psalm during tests
+        if: matrix.composer-minimum-stability
+        run: composer remove --dev --no-update vimeo/psalm psalm/plugin-phpunit
 
       - name: "Install dependencies"
         uses: ramsey/composer-install@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,10 @@ jobs:
             composer-options: "--prefer-dist --ignore-platform-req=php+"
           - php-version: "8.5"
             composer-options: "--prefer-dist --ignore-platform-req=php+"
-            
+          - php-version: "8.4"
+            composer-options: "--prefer-dist --ignore-platform-req=php+"
+            composer-minimum-stability: "beta"
+            symfony-version: "^8.0.0-BETA1"
 
     steps:
       - name: "Checkout"
@@ -47,12 +50,20 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
           ini-values: "zend.assertions=1"
+          tools: flex
+
+      - name: Configure Composer minimum-stability
+        if: matrix.composer-minimum-stability
+        run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
+
 
       - name: "Install dependencies"
         uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.deps }}
           composer-options: ${{ matrix.composer-options }}
+        env:
+            SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --coverage-clover=coverage.xml"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,7 +45,6 @@ jobs:
           tools: flex
 
       - name: Remove Psalm during tests
-        if: ${{ matrix.composer-minimum-stability || matrix.php-version == '8.4' }}
         run: composer remove --dev --no-update vimeo/psalm psalm/plugin-phpunit
 
       - name: "Install dependencies"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,14 +26,14 @@ jobs:
         deps:
           - "highest"
         composer-options:
-          - "--prefer-dist"
+          - ""
         include:
           - php-version: "7.4"
             deps: "lowest"
           - php-version: "8.5"
-            composer-options: "--prefer-dist --ignore-platform-req=php+"
+            composer-options: "--ignore-platform-req=php+"
           - php-version: "8.4"
-            composer-options: "--prefer-dist --ignore-platform-req=php+"
+            composer-options: "--ignore-platform-req=php+"
             composer-minimum-stability: "beta"
             symfony-version: "^8.0.0-BETA1"
 
@@ -63,7 +63,7 @@ jobs:
         uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.deps }}
-          composer-options: ${{ matrix.composer-options }}
+          composer-options: "--prefer-dist ${{ matrix.composer-options }}"
         env:
             SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
-        "php-cs-fixer/shim": "^3.88",
+        "friendsofphp/php-cs-fixer": "^3.88",
         "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/polyfill-php80": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.88",
+        "php-cs-fixer/shim": "^3.88",
         "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/polyfill-php80": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.88",
-        "symfony/console": "^5.4 || ^6.0 || ^7.0",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/polyfill-php80": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR increase version constraints on `symfony/*` packages to allow Symfony 8, which will be released this month.

Related to https://github.com/facile-it/paraunit/pull/344